### PR TITLE
🐛fix: wallet 응답값에 keystorefilename 추가

### DIFF
--- a/src/main/java/com/picktartup/wallet/config/WebClientConfig.java
+++ b/src/main/java/com/picktartup/wallet/config/WebClientConfig.java
@@ -16,7 +16,7 @@ public class WebClientConfig {
     @Value("${service.user.url}")
     private String userServiceUrl;
 
-    @Value("${service.coin .url}")
+    @Value("${service.coin.url}")
     private String coinServiceUrl;
 
     @Bean

--- a/src/main/java/com/picktartup/wallet/service/WalletService.java
+++ b/src/main/java/com/picktartup/wallet/service/WalletService.java
@@ -131,6 +131,7 @@ public class WalletService {
                         .userId(wallet.getUserId())
                         .address(wallet.getAddress())
                         .balance(wallet.getBalance().setScale(6, RoundingMode.DOWN))
+                        .keystoreFilename(wallet.getKeystoreFilename())
                         .status(wallet.getStatus())
                         .createdAt(wallet.getCreatedAt())
                         .updatedAt(wallet.getUpdatedAt())


### PR DESCRIPTION
### 👀 관련 이슈
- #16 

### ✨ 작업한 내용
- **keystorefilename 필드 추가**
`http://localhost:8080/api/v1/wallets/user/3`

contractservice 에서 투자를 할 때 지갑 정보 조회가 필요합니다.

지갑 정보 조회 시 keystorefilename 을 받아와서 자격증명을 진행하기 때문에 keystorefilename이 필요한데 반환값에 없어서 추가하였습니다.


### 🌀 PR Point
X

### 🍰 참고사항
X

