### PR TITLE
fix: 민팅 시 CoinTransaction 검증 로직 제거

### DIFF
--- a/src/main/java/com/picktartup/wallet/service/TokenService.java
+++ b/src/main/java/com/picktartup/wallet/service/TokenService.java
@@ -114,7 +114,7 @@ public class TokenService {
         userServiceClient.validateUserExists(request.getUserId());
 
         // 2. 주문 검증
-        coinServiceClient.validatePayment(request.getTransactionId(), request.getUserId(), request.getAmount());
+        // coinServiceClient.validatePayment(request.getTransactionId(), request.getUserId(), request.getAmount());
 
         // 3. 사용자 지갑 조회
         Wallet userWallet = walletRepository.findByUserId(request.getUserId())


### PR DESCRIPTION
### ✨ 작업한 내용
- coinServiceClient.validatePayment 주문 검증 제거 (coin service에서 검증하기 때문에 중복됨)
