### PR TITLE
✏️fix: 배포 서버 주소 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,6 @@ contract:
 
 service:
   user:
-    url: http://192.168.0.143:32450/user
+    url: http://192.168.0.142:30798/user
   coin:
-    url: http://192.168.0.143:32450/coin
+    url: http://192.168.0.142:30798/coin


### PR DESCRIPTION
### 👀 관련 이슈
- #16 

### ✨ 작업한 내용
argocd 재배포에 따른 온프레미스 서버 주소 변경

### 🌀 PR Point
http://192.168.0.143:32450 -> http://192.168.0.142:30798/ 로 변경되었습니다.
