### PR TITLE
🐛fix: 일부 서비스 eks 로 전환됨에 따른 url 수정 및 dns 변환 추가

### DIFF
--- a/src/main/java/com/picktartup/wallet/config/WebClientConfig.java
+++ b/src/main/java/com/picktartup/wallet/config/WebClientConfig.java
@@ -6,9 +6,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
 
 @Slf4j
 @Configuration
@@ -24,12 +28,16 @@ public class WebClientConfig {
         return WebClient.builder()
                 .baseUrl(userServiceUrl)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .filter(ExchangeFilterFunction.ofRequestProcessor(
                         clientRequest -> {
                             log.debug("Request: {} {}", clientRequest.method(), clientRequest.url());
                             return Mono.just(clientRequest);
                         }
                 ))
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create()
+                        .followRedirect(true)
+                        .responseTimeout(Duration.ofSeconds(10))))
                 .build();
     }
 
@@ -38,12 +46,16 @@ public class WebClientConfig {
         return WebClient.builder()
                 .baseUrl(coinServiceUrl)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .filter(ExchangeFilterFunction.ofRequestProcessor(
                         clientRequest -> {
                             log.debug("Request: {} {}", clientRequest.method(), clientRequest.url());
                             return Mono.just(clientRequest);
                         }
                 ))
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create()
+                        .followRedirect(true)
+                        .responseTimeout(Duration.ofSeconds(10))))
                 .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,6 @@ contract:
 
 service:
   user:
-    url: http://192.168.0.142:32450/user
+    url: https://picktartup.com
   coin:
-    url: http://192.168.0.142:32450/coin
+    url: https://picktartup.com


### PR DESCRIPTION
### 👀 관련 이슈
- #35 

### ✨ 작업한 내용
1. application.yml URL 수정
```yaml
service:
  user:
    url: https://picktartup.com
  coin:
    url: https://picktartup.com
```

2. webclient 설정 수정
서비스들끼리 통신은 cluster ip 로 이루어졌기 때문에 dns 전환하는 기능이 없다. 따라서 도메인 주소가 돌아오면 ip 주소로 변환하지 못하기 때문에 통신할 때마다 webclient 에 dns 주소로 전환할 수 있도록 아래와 같이 수정해야한다.
<img width="731" alt="image" src="https://github.com/user-attachments/assets/a5d9b3fe-1e00-4beb-a701-071cdae6a32f">


### 🌀 PR Point
WebClientConfig 쪽 확인해주시면 됩니다.

### 🍰 참고사항
기존: 워커노드 IP 기반 통신 (http://192.168.0.142:32450/)
변경: 도메인 기반 통신 (https://picktartup.com/)
 추가 정보 ->  https://github.com/Picktartup/Picktartup-contractservice/pull/40 링크 참고
